### PR TITLE
Various fixes

### DIFF
--- a/site/api/processing.py
+++ b/site/api/processing.py
@@ -248,7 +248,7 @@ def create_genre_data(genre_df: pd.DataFrame) -> list[dict]:
 def create_abs_avg_plot_data(
     format: Literal["anime", "manga"], abs_score_diff: float, avg_score_diff: float
 ) -> tuple[list[dict], list[dict]]:
-    existing_data_path = "./api/existing_user_data.parquet"
+    existing_data_path = f"./api/existing_{format}_data.parquet"
     file_exists = os.path.isfile(existing_data_path)
 
     if file_exists:
@@ -327,7 +327,7 @@ def create_abs_avg_plot_data(
 def create_obscurity_data(
     format: Literal["anime", "manga"], format_df: pd.DataFrame
 ) -> tuple[list[dict], int]:
-    existing_data_path = "./api/existing_pop_data.parquet"
+    existing_data_path = f"./api/existing_{format}_pop_data.parquet"
     file_exists = os.path.isfile(existing_data_path)
     user_pop = int(round(format_df["popularity"].mean()))
 

--- a/site/frontend/src/lib/components/Bar.svelte
+++ b/site/frontend/src/lib/components/Bar.svelte
@@ -97,7 +97,7 @@
 				transform="translate({10}, {(height - padding.bottom + padding.top) /
 					2}) rotate(-90)"
 			>
-				<text style="text-anchor: middle;">% of Users →</text>
+				<text style="text-anchor: middle;">% of Users</text>
 			</g>
 		</g>
 		<g class="bars">
@@ -130,18 +130,22 @@
 		</g>
 		<g class="axis x-axis">
 			{#each data as point, i}
-				<g class="text-xs fill-current font-semibold" style="text-anchor: middle;" transform="translate({xScale(i)}, {height - 55})">
-					<text x={diverging ? "5" : "6.5"} y="5">
+				<g
+					class="{data.length > 20 ? "text-xs" : "text-sm"} fill-current font-semibold"
+					style="text-anchor: middle;"
+					transform="translate({xScale(i) + barWidth * 0.2}, {height - 55})"
+				>
+					<text y="5">
 						{point[x]}
 					</text>
 				</g>
 			{/each}
 			<g
 				class="tick"
-				transform="translate({(width + padding.left - padding.right) /
+				transform="translate({(width + padding.left - barWidth * 0.55) /
 					2}, {height - 5})"
 			>
-				<text>{xLabel} →</text>
+				<text>{xLabel}</text>
 			</g>
 		</g>
 	</svg>

--- a/site/frontend/src/lib/components/Bar.svelte
+++ b/site/frontend/src/lib/components/Bar.svelte
@@ -122,7 +122,7 @@
 						class="fill-primary font-bold text-sm md:text-lg"
 						style="text-anchor: middle;"
 						x={xScale(i) + barWidth * 0.2}
-						y={height - 22}
+						y={height - 28}
 						>{direction} &gt;{percentile}% of Users
 					</text>
 				{/if}

--- a/site/frontend/src/lib/components/ObscurityBar.svelte
+++ b/site/frontend/src/lib/components/ObscurityBar.svelte
@@ -25,8 +25,8 @@
 		username: string;
 	} = $props();
 
-	let width = $state(800);
-	let height = $state(400);
+	let width = $state(913);
+	let height = $state(525);
 	const padding = { top: 20, bottom: 40, left: 130, right: 0 };
 
 	let yMax = $derived(max(data, (d) => +d[y]));
@@ -177,7 +177,7 @@
 						style="text-anchor: middle;"
 						transform="translate({xScale(i)}, {height - 30})"
 					>
-						<text x="17" y="5">
+						<text x={Math.ceil((barWidth * 0.4) / 2)} y="5">
 							{pct}%
 						</text>
 					</g>
@@ -185,8 +185,7 @@
 			{/each}
 			<g
 				class="tick"
-				transform="translate({(width + padding.left - 37) / 2}, {height -
-					1})"
+				transform="translate({(width + padding.left - 37) / 2}, {height - 1})"
 			>
 				<text>{xLabel} →</text>
 			</g>

--- a/site/frontend/src/lib/components/ObscurityBar.svelte
+++ b/site/frontend/src/lib/components/ObscurityBar.svelte
@@ -135,9 +135,9 @@
 			{/each}
 			<g
 				class="tick"
-				transform="translate({10}, {(height - padding.bottom) / 2}) rotate(-90)"
+				transform="translate({10}, {(height - padding.bottom + padding.top) / 2}) rotate(-90)"
 			>
-				<text style="text-anchor: middle;">{yLabel} →</text>
+				<text style="text-anchor: middle;">{yLabel}</text>
 			</g>
 		</g>
 		<g class="bars">
@@ -157,9 +157,9 @@
 					{#if scoreVariable == point[y]}
 						<text
 							class="fill-primary font-bold text-sm md:text-lg"
-							style="text-anchor: middle;"
-							x={xScale(i) + 15}
+							x={xScale(i) + barWidth * 0.2}
 							y={yScale(point[y]) - 10}
+							style="text-anchor: middle;"
 							>{username}
 						</text>
 					{/if}
@@ -174,20 +174,16 @@
 				>
 					<g
 						class="tick"
-						style="text-anchor: middle;"
-						transform="translate({xScale(i)}, {height - 30})"
+						transform="translate({xScale(i) + barWidth * 0.2}, {height - 30})"
 					>
-						<text x={Math.ceil((barWidth * 0.4) / 2)} y="5">
+						<text x="1" y="5">
 							{pct}%
 						</text>
 					</g>
 				</g>
 			{/each}
-			<g
-				class="tick"
-				transform="translate({(width + padding.left - 37) / 2}, {height - 1})"
-			>
-				<text>{xLabel} →</text>
+			<g class="tick" transform="translate({(width + padding.left - barWidth * 0.6) / 2}, {height - 1})">
+				<text>{xLabel}</text>
 			</g>
 		</g>
 		{#if tooltipVisible}
@@ -222,7 +218,6 @@
 
 	.tick text {
 		@apply fill-current text-current font-semibold;
-		text-anchor: start;
 	}
 
 	.tick line {

--- a/site/frontend/src/routes/+layout.svelte
+++ b/site/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import "../app.css";
   import { ModeWatcher } from "mode-watcher";
   import { navigating } from "$app/stores";
+  import { Sun, MoonStar } from "lucide-svelte";
 </script>
 
 <svelte:head>
@@ -16,11 +17,12 @@
 </svelte:head>
 
 <ModeWatcher />
+
 <div class="md:sticky z-10 top-0 h-0">
   <div class="absolute z-10 right-0 p-4">
-    <Button on:click={toggleMode} variant="outline" size="sm">
-      <span class="hidden dark:flex">Dark</span>
-      <span class="dark:hidden">Light</span>
+    <Button onclick={toggleMode} variant="outline" size="sm">
+      <span class="hidden dark:flex"><MoonStar /></span>
+      <span class="dark:hidden"><Sun /></span>
     </Button>
   </div>
 </div>

--- a/site/frontend/src/routes/dashboard/+page.svelte
+++ b/site/frontend/src/routes/dashboard/+page.svelte
@@ -268,7 +268,7 @@
   <AnimatedScroll>
     <DashboardContainer class="space-y-6">
       <H2 class="text-center text-white border-white text-6xl">obscurity</H2>
-      <Card.Root class="m-auto w-full overflow-x-auto shadow-2xl">
+      <Card.Root class="m-auto w-full md:w-auto overflow-x-auto shadow-2xl">
         <Card.Header>
           <Card.Title class="text-4xl text-primary">
             Obscurity

--- a/site/frontend/src/routes/dashboard/+page.svelte
+++ b/site/frontend/src/routes/dashboard/+page.svelte
@@ -138,7 +138,7 @@
               scoreVariable={data.insights.absScoreDiff}
               colorX1="fill-primary"
               colorX2="fill-plot-accent"
-              xLabel="Difference"
+              xLabel="Score Difference"
               diverging={false}
             />
           </Card.Content>
@@ -165,7 +165,7 @@
               scoreVariable={data.insights.avgScoreDiff}
               colorX1="fill-plot-accent"
               colorX2="fill-destructive"
-              xLabel="Positive"
+              xLabel="Positivity"
               diverging={true}
             />
           </Card.Content>


### PR DESCRIPTION
- Calculate UI spacing using bar width to ensure consistency across different lengths of labels and different chart configurations.
- Fix light/dark mode toggle by migrating from legacy `on:click` to Svelte 5's `onclick`.
- Switch to nicer icons on light/dark mode toggle
- Fix bug where `abs_data`, `avg_data` and `pop_data` were not generated independently for anime/manga queries. 